### PR TITLE
Improve timing and speculative decoding metrics for vllm models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 *outputs
 *.hydra
 *.log
+slurm/
+benchmark/

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ __pycache__
 *.hydra
 *.log
 slurm/
-benchmark/
+benchmark*/
+spec_decode_metrics/

--- a/README.md
+++ b/README.md
@@ -20,9 +20,27 @@ tar -xvf checkpoints/${model}/${model}.tar.gz -C checkpoints/${model}/
 Repeat for `model=progen2-xlarge`.
 
 ## Basic Generation
+
+With vllm (skip sanity check):
+
 ```
-python sample.py --model progen2-xlarge --num-samples 1 --max-length 512
+python sample.py --model progen2-xlarge --num-samples 1 --max-length 512 --use_vllm=True --sanity=False
 ```
+
+Without vllm:
+
+```
+python sample.py --model progen2-xlarge --num-samples 1 --max-length 512 --use_vllm=False
+```
+
+## Run modes
+
+`sample.py` provides four main run modes:
+
+- `--sanity`: sanity check that the model cross-entropy is correct on a test sequence. NOTE: this does not currently work with vllm.
+- `--sample`: whether to sample from the model.
+- `--benchmark`: whether to run the timing benchmark.
+- `--log_spec_decode_metrics`: whether to log speculative decoding metrics. This is mutually exclusive with `--sample=True` and `--benchmark=True`, and requires `--use_vllm=True`.
 
 ## Sampling with Speculative Decoding
 ```

--- a/benchmark_functions.py
+++ b/benchmark_functions.py
@@ -122,9 +122,13 @@ def benchmark_vllm_model(
         temperature=temp,
         top_p=top_p,
         max_tokens=max_length,
+        detokenize=False,  # Do not detokenize for benchmarking
     )
-    input_ids = torch.tensor(tokenizer.encode(context).ids).view([1, -1]).to(device)
-    prompts = TokensPrompt(prompt_token_ids=input_ids)
+    if tokenizer is None:
+        prompts = context
+    else:
+        input_ids = torch.tensor(tokenizer.encode(context).ids).view([1, -1]).to(device)
+        prompts = TokensPrompt(prompt_token_ids=input_ids)
 
     def generate():
         model.generate(prompts, sampling_params)

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,53 @@
+import logging
+
+from pythonjsonlogger import jsonlogger
+from vllm.engine.metrics_types import StatLoggerBase, Stats, SupportsMetricsInfo
+from vllm.spec_decode.metrics import SpecDecodeWorkerMetrics
+
+
+def init_logger(name):
+    return logging.getLogger(name)
+
+
+def init_vllm_json_file_logger(path):
+    logger = init_logger("progen_vllm")
+    logger.setLevel(logging.INFO)
+    log_handler = logging.FileHandler(path)
+    formatter = jsonlogger.JsonFormatter()
+    log_handler.setFormatter(formatter)
+    logger.addHandler(log_handler)
+    return logger
+
+
+class VllmStatLogger(StatLoggerBase):
+    """VLLM stat logger."""
+
+    def __init__(self, logger: logging.Logger, local_interval: float = 0.1) -> None:
+        super().__init__(local_interval)
+        self.logger = logger
+
+    def log(self, stats: Stats) -> None:
+        self.maybe_update_spec_decode_metrics(stats)
+        if self.spec_decode_metrics is not None:
+            metrics_dict = self._format_spec_decode_metrics_str(
+                self.spec_decode_metrics
+            )
+            self.logger.info(metrics_dict)
+
+        self.spec_decode_metrics = None
+
+    def _format_spec_decode_metrics_str(self, metrics: SpecDecodeWorkerMetrics) -> dict:
+        return {
+            key: getattr(metrics, key)
+            for key in [
+                "draft_acceptance_rate",
+                "system_efficiency",
+                "num_spec_tokens",
+                "accepted_tokens",
+                "draft_tokens",
+                "emitted_tokens",
+            ]
+        }
+
+    def info(self, type: str, obj: SupportsMetricsInfo) -> None:
+        raise NotImplementedError

--- a/progen/sampling.py
+++ b/progen/sampling.py
@@ -22,13 +22,14 @@ def sample(device, model, tokenizer, context, max_length, num_return_sequences, 
         return tokenizer.decode_batch(as_lists(tokens_batch))
 
 
-def sample_vllm(device, model: LLM, tokenizer, context, max_length, num_return_sequences, top_p, temp):
+def sample_vllm(device, model: LLM, tokenizer, context, max_length, num_return_sequences, top_p, temp, frequency_penalty):
     """Sample from the VLLM model."""
     sampling_params = SamplingParams(
         n=num_return_sequences,
         temperature=temp,
         top_p=top_p,
         max_tokens=max_length,
+        frequency_penalty=frequency_penalty,
     )
     if tokenizer is None:
         outputs = model.generate(context, sampling_params)

--- a/progen/utils.py
+++ b/progen/utils.py
@@ -2,6 +2,7 @@ import random
 import time
 import os
 import abc
+import datetime
 from typing import Tuple, Union
 
 import torch
@@ -42,11 +43,16 @@ def set_seed(seed, deterministic=True):
 
 
 def get_benchmark_results_save_path(
-    root_dir, model_name, use_vllm, num_samples, max_len, speculative_model
+    root_dir, model_name, use_vllm, num_samples, max_len, speculative_model,
+    add_timestamp=True
 ):
-    path = f"{model_name}_vllm_{use_vllm}_samples_{num_samples}_len_{max_len}"
+    path = f"{model_name}/vllm_{use_vllm}_samples_{num_samples}_len_{max_len}"
     if speculative_model is not None:
         path += f"_spec_{speculative_model}"
+
+    if add_timestamp:
+        path += f"-{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
+
     path = f"{path}.json"
     return os.path.join(root_dir, path)
 

--- a/progen/utils.py
+++ b/progen/utils.py
@@ -42,7 +42,7 @@ def set_seed(seed, deterministic=True):
         torch.backends.cudnn.benchmark = not deterministic
 
 
-def get_benchmark_results_save_path(
+def get_benchmark_results_save_dir(
     root_dir, model_name, use_vllm, num_samples, max_len, speculative_model,
     add_timestamp=True
 ):
@@ -53,7 +53,6 @@ def get_benchmark_results_save_path(
     if add_timestamp:
         path += f"-{datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
 
-    path = f"{path}.json"
     return os.path.join(root_dir, path)
 
 
@@ -68,8 +67,10 @@ def create_model(
     tokenizer=None,
     speculative_model=None,
     num_speculative_tokens=None,
+    ngram_prompt_lookup_min=1,
     ngram_prompt_lookup_max=4,
     rope_dtype="float32",
+    disable_log_stats=False,
 ):
     if use_vllm:
         assert (speculative_model is None) == (num_speculative_tokens is None), (
@@ -93,7 +94,9 @@ def create_model(
             hf_overrides=hf_overrides,
             speculative_model=speculative_model,
             num_speculative_tokens=num_speculative_tokens,
+            ngram_prompt_lookup_min=ngram_prompt_lookup_min,
             ngram_prompt_lookup_max=ngram_prompt_lookup_max,
+            disable_log_stats=disable_log_stats,
         )
 
     assert rope_dtype == "float32", "rope_dtype must be float32 when not using VLLM"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ accelerate
 einops
 termcolor # for fun viz during printing
 ipykernel
+python-json-logger

--- a/sample.py
+++ b/sample.py
@@ -16,6 +16,10 @@ from progen.utils import create_model, create_tokenizer_custom, set_env, set_see
 import logger as logger_utils
 
 
+TIME_BENCHMARK_DIR = "benchmark"
+SPEC_DECODE_METRICS_DIR = "spec_decode_metrics"
+
+
 def none_or_val(value, dtype=str):
     return None if value == 'None' else dtype(value)
 
@@ -187,18 +191,17 @@ def main():
                 print(i)
                 print(truncation)
 
-    save_dir = get_benchmark_results_save_dir(
-        root_dir='benchmark',
-        model_name=args.model,
-        use_vllm=args.use_vllm,
-        num_samples=args.num_samples,
-        max_len=args.max_length,
-        speculative_model=args.speculative_model,
-    )
-    save_dir = pathlib.Path(save_dir)
-
     # (6) Spec decoding metrics
     if args.log_spec_decode_metrics:
+        save_dir = get_benchmark_results_save_dir(
+            root_dir=SPEC_DECODE_METRICS_DIR,
+            model_name=args.model,
+            use_vllm=args.use_vllm,
+            num_samples=args.num_samples,
+            max_len=args.max_length,
+            speculative_model=args.speculative_model,
+        )
+        save_dir = pathlib.Path(save_dir)
         if not save_dir.exists():
             save_dir.mkdir(parents=True)
         path = save_dir / "spec_decode_metrics.json"
@@ -242,6 +245,16 @@ def main():
 
         # Add args to results
         results.update(vars(args))
+
+        save_dir = get_benchmark_results_save_dir(
+            root_dir=TIME_BENCHMARK_DIR,
+            model_name=args.model,
+            use_vllm=args.use_vllm,
+            num_samples=args.num_samples,
+            max_len=args.max_length,
+            speculative_model=args.speculative_model,
+        )
+        save_dir = pathlib.Path(save_dir)
 
         if not save_dir.exists():
             save_dir.mkdir(parents=True)

--- a/sample.py
+++ b/sample.py
@@ -12,7 +12,8 @@ import torch
 
 import benchmark_functions
 from progen.sampling import compute_prompt_cross_entropy_vllm, sample, sample_vllm, cross_entropy, truncate
-from progen.utils import create_model, create_tokenizer_custom, set_env, set_seed, print_time, get_benchmark_results_save_path
+from progen.utils import create_model, create_tokenizer_custom, set_env, set_seed, print_time, get_benchmark_results_save_dir
+import logger as logger_utils
 
 
 def none_or_val(value, dtype=str):
@@ -39,6 +40,7 @@ def main():
     parser.add_argument('--rng-deterministic', default=True, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--p', type=float, default=0.95)
     parser.add_argument('--t', type=float, default=0.2)
+    parser.add_argument('--frequency_penalty', type=float, default=0)
     parser.add_argument('--max-length', type=int, default=256)
     parser.add_argument('--num-samples', type=int, default=1)
     parser.add_argument('--fp16', default=True, type=lambda x: (str(x).lower() == 'true'))
@@ -46,13 +48,26 @@ def main():
     parser.add_argument('--sanity', default=True, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--sample', default=True, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--benchmark', default=False, type=lambda x: (str(x).lower() == 'true'))
+    parser.add_argument('--log_spec_decode_metrics', default=False, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--use_vllm', default=True, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--separate_tokenizer', default=False, type=lambda x: (str(x).lower() == 'true'))
     parser.add_argument('--speculative_model', type=none_or_val, choices=speculative_models, default=None)
     parser.add_argument('--num_speculative_tokens', type=lambda x: none_or_val(x, dtype=int), default=None)
+    parser.add_argument('--ngram_prompt_lookup_min', type=int, default=1)
     parser.add_argument('--ngram_prompt_lookup_max', type=int, default=4)
     parser.add_argument('--rope_dtype', type=str, default='float32')
     args = parser.parse_args()
+
+    assert not (
+        args.log_spec_decode_metrics and (args.sample or args.benchmark)
+    ), "log_spec_decode_metrics cannot be used with sample or benchmark"
+    if args.log_spec_decode_metrics:
+        assert (
+            args.use_vllm
+        ), "log_spec_decode_metrics can only be used with use_vllm=True"
+        assert (
+            args.speculative_model is not None
+        ), "log_spec_decode_metrics can only be used with a speculative model"
 
     # (2) preamble
 
@@ -90,8 +105,12 @@ def main():
             tokenizer="tokenizer" if tokenizer is None else None,
             speculative_model=spec_model,
             num_speculative_tokens=args.num_speculative_tokens,
+            ngram_prompt_lookup_min=args.ngram_prompt_lookup_min,
             ngram_prompt_lookup_max=args.ngram_prompt_lookup_max,
             rope_dtype=args.rope_dtype,
+            # Enable logging stats when collecting speculative decoding metrics.
+            # Otherwise, disable them to speed up generation.
+            disable_log_stats=not args.log_spec_decode_metrics,
         )
         if not args.use_vllm:
             model = model.to(device)
@@ -144,7 +163,17 @@ def main():
     if args.sample:
         with print_time('sampling'):
             if args.use_vllm:
-                completions, outputs = sample_vllm(device=device, model=model, tokenizer=tokenizer, context=args.context, num_return_sequences=args.num_samples, temp=args.t, top_p=args.p, max_length=args.max_length)
+                completions, outputs = sample_vllm(
+                    device=device,
+                    model=model,
+                    tokenizer=tokenizer,
+                    context=args.context,
+                    max_length=args.max_length,
+                    num_return_sequences=args.num_samples,
+                    top_p=args.p,
+                    temp=args.t,
+                    frequency_penalty=args.frequency_penalty,
+                )
             else:
                 completions = sample(device=device, model=model, tokenizer=tokenizer, context=args.context, pad_token_id=tokenizer.encode('<|pad|>').ids[0], num_return_sequences=args.num_samples, temp=args.t, top_p=args.p, max_length=args.max_length)
 
@@ -158,7 +187,41 @@ def main():
                 print(i)
                 print(truncation)
 
-    # (6) benchmark
+    save_dir = get_benchmark_results_save_dir(
+        root_dir='benchmark',
+        model_name=args.model,
+        use_vllm=args.use_vllm,
+        num_samples=args.num_samples,
+        max_len=args.max_length,
+        speculative_model=args.speculative_model,
+    )
+    save_dir = pathlib.Path(save_dir)
+
+    # (6) Spec decoding metrics
+    if args.log_spec_decode_metrics:
+        if not save_dir.exists():
+            save_dir.mkdir(parents=True)
+        path = save_dir / "spec_decode_metrics.json"
+        # Create empty file
+        path.touch(exist_ok=False)
+        # Add vllm logger
+        json_file_logger = logger_utils.init_vllm_json_file_logger(path)
+        vllm_json_logger = logger_utils.VllmStatLogger(json_file_logger)
+        model.llm_engine.add_logger("progen_vllm_benchmark", vllm_json_logger)
+
+        benchmark_functions.collect_speculative_decoding_metrics(
+            model,
+            tokenizer,
+            args.context,
+            device,
+            args.max_length,
+            args.num_samples,
+            top_p=args.p,
+            temp=args.t,
+            frequency_penalty=args.frequency_penalty,
+        )
+
+    # (7) timing benchmark
 
     if args.benchmark:
         if args.use_vllm:
@@ -170,8 +233,9 @@ def main():
                 device,
                 args.max_length,
                 args.num_samples,
-                args.p,
-                args.t,
+                top_p=args.p,
+                temp=args.t,
+                frequency_penalty=args.frequency_penalty,
             )
         else:
             raise NotImplementedError('benchmarking not implemented for non-VLLM models')
@@ -179,17 +243,9 @@ def main():
         # Add args to results
         results.update(vars(args))
 
-        save_path = get_benchmark_results_save_path(
-            root_dir='benchmark',
-            model_name=args.model,
-            use_vllm=args.use_vllm,
-            num_samples=args.num_samples,
-            max_len=args.max_length,
-            speculative_model=args.speculative_model,
-        )
-        if not pathlib.Path(save_path).parent.exists():
-            pathlib.Path(save_path).parent.mkdir(parents=True)
-        with open(save_path, 'w') as f:
+        if not save_dir.exists():
+            save_dir.mkdir(parents=True)
+        with open(save_dir / 'time_benchmark.json', 'w') as f:
             json.dump(results, f)
 
 


### PR DESCRIPTION
- Timing benchmark
  - Save all times so we can later compute any desired statistics and confidence intervals.
  - Fix `n_warmup` and `n_repeat` to use iterations and not just amount of time.
- Speculative decoding metrics: add a mode to log these metrics (e.g., acceptance rate) using a JSON logger.
- Add `frequency_penalty` param to `sample.py` args.